### PR TITLE
parallel workflow using grep to select jobs

### DIFF
--- a/workflow-examples/parallel-from-grep/README.md
+++ b/workflow-examples/parallel-from-grep/README.md
@@ -1,0 +1,23 @@
+# Synopsis
+
+An example showing how to search for a list of existing jobs and
+triggering all of them in parallel.
+
+# Caveats
+
+* Calling other jobs is not the most idiomatic way to use the Worflow DSL, 
+however, the chance of re-using existing jobs is always welcome under certain
+circumstances.
+
+* Due to limitations in Workflow - i.e.,
+[JENKINS-26481](https://issues.jenkins-ci.org/browse/JENKINS-26481) -
+it's not really possible to use Groovy closures or syntax that depends
+on closures, so you can't do the Groovy standard of using
+.collectEntries on a list and generating the steps as values for the
+resulting entries. You also can't use the standard Java syntax for For
+loops - i.e., "for (String s: strings)" - and instead have to use old
+school counter-based for loops.
+* There is no need for the generation of the step itself to be in a
+separate method. I've opted to do so here to show how to return a step
+closure from a method.
+

--- a/workflow-examples/parallel-from-grep/parallelFromGrep.groovy
+++ b/workflow-examples/parallel-from-grep/parallelFromGrep.groovy
@@ -1,0 +1,38 @@
+import jenkins.model.*
+
+// While you can't use Groovy's .collect or similar methods currently, you can
+// still transform a list into a set of actual build steps to be executed in
+// parallel.
+
+def stepsForParallel = [:]
+
+// Since this method uses grep/collect it needs to be annotated with @NonCPS
+// It returns a simple string map so the workflow can be serialized
+@NonCPS
+def jobs(jobRegexp) {
+  Jenkins.instance.getAllItems()
+         .grep { it.name ==~ ~"${jobRegexp}"  }
+         .collect { [ name : it.name.toString(),
+                      fullName : it.fullName.toString() ] }
+}
+
+j = jobs('test-(dev|stage)-(unit|integration)')
+for (int i=0; i < j.size(); i++) {
+    stepsForParallel["${j[i].name}"] = transformIntoStep(j[i].fullName)
+}
+
+// Actually run the steps in parallel - parallel takes a map as an argument,
+// hence the above.
+parallel stepsForParallel
+
+// Take the string and echo it.
+def transformIntoStep(jobFullName) {
+    // We need to wrap what we return in a Groovy closure, or else it's invoked
+    // when this method is called, not when we pass it to parallel.
+    // To do this, you need to wrap the code below in { }, and either return
+    // that explicitly, or use { -> } syntax.
+    return {
+       // Job parameters can be added to this step
+       build jobFullName
+    }
+}


### PR DESCRIPTION
An example of using a @NonCPS annotated method to select existing jobs and creating steps for each job to run in parallel.